### PR TITLE
Add user agent and ensure politeness in testing

### DIFF
--- a/doi-proxy/src/main/java/no/unit/nva/doi/CrossRefClient.java
+++ b/doi-proxy/src/main/java/no/unit/nva/doi/CrossRefClient.java
@@ -35,6 +35,8 @@ public class CrossRefClient {
     private static final String DOI_EXAMPLES = "10.1000/182, https://doi.org/10.1000/182";
     public static final String ILLEGAL_DOI_MESSAGE = "Illegal DOI:%s. Valid examples:" + DOI_EXAMPLES;
     public static final String FETCH_ERROR = "CrossRefClient failed while trying to fetch:";
+    public static final String CROSSREF_USER_AGENT =
+            "nva-fetch-doi/1.0 (https://github.com/BIBSYSDEV/nva-fetch-doi; mailto:support@unit.no)";
 
     private final transient HttpClient httpClient;
     private static final Logger logger = LoggerFactory.getLogger(CrossRefClient.class);
@@ -80,6 +82,7 @@ public class CrossRefClient {
     private HttpRequest createRequest(URI doiUri) {
         return HttpRequest.newBuilder(doiUri)
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.USER_AGENT, CROSSREF_USER_AGENT)
             .timeout(Duration.ofSeconds(TIMEOUT_DURATION))
             .GET()
             .build();

--- a/doi-proxy/src/test/java/no/unit/nva/doi/CrossRefClientTest.java
+++ b/doi-proxy/src/test/java/no/unit/nva/doi/CrossRefClientTest.java
@@ -1,5 +1,6 @@
 package no.unit.nva.doi;
 
+import static no.unit.nva.doi.CrossRefClient.CROSSREF_USER_AGENT;
 import static no.unit.nva.doi.CrossRefClient.WORKS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -13,12 +14,14 @@ import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+
 import no.bibsys.aws.tools.IoUtils;
 
 import no.unit.nva.doi.utils.HttpResponseStatus200;
 import no.unit.nva.doi.utils.HttpResponseStatus404;
 import no.unit.nva.doi.utils.HttpResponseStatus500;
 import no.unit.nva.doi.utils.MockHttpClient;
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,8 @@ public class CrossRefClientTest {
 
     public static final String ERROR_MESSAGE = "404 error message";
     public static final String ILLEGAL_DOI_STRING = "doi:" + DOI_STRING;
+    public static final String HTTPS = "https";
+    public static final String HTTP_DOI_URI = "http://doi.dx.org/10.000/0001";
 
     private CrossRefClient crossRefClient;
 
@@ -45,31 +50,51 @@ public class CrossRefClientTest {
     @DisplayName("createTargetUrl returns a valid Url for DOI strings that are not DOI URLs")
     @Test
     public void createTargetUrlReturnsAValidUrlForDoiStringThatIsNotDoiURL()
-        throws URISyntaxException {
+            throws URISyntaxException {
         String expected = String.join("/", CrossRefClient.CROSSREF_LINK, WORKS, DOI_STRING);
 
         String output = crossRefClient.createUrlToCrossRef(DOI_STRING).toString();
         assertThat(output, is(equalTo(expected)));
     }
 
+    @DisplayName("Requests to Crossref are made politely with https")
+    @Test
+    public void crossRefClientIsConfiguredToUseHttps() throws URISyntaxException {
+        var crossRefUri = crossRefClient.createUrlToCrossRef(HTTP_DOI_URI);
+        assertThat(crossRefUri.getScheme(), equalTo(HTTPS));
+    }
+
+    @DisplayName("Requests to Crossref are made politely with user agent")
+    @Test
+    public void crossRefHttpClientIsConfiguredToUseUserAgent() throws URISyntaxException, IOException {
+        var responseBody = IoUtils.resourceAsString(CROSS_REF_SAMPLE_PATH);
+        var httpClient = new MockHttpClient<>(new HttpResponseStatus200<>(responseBody));
+        var crossRefClient = new CrossRefClient(httpClient);
+        crossRefClient.fetchDataForDoi(DOI_STRING);
+        var httpRequest = httpClient.getHttpRequest();
+        var headers = httpRequest.headers().map();
+        assertTrue(headers.containsKey(HttpHeaders.USER_AGENT));
+        assertTrue(headers.get(HttpHeaders.USER_AGENT).contains(CROSSREF_USER_AGENT));
+    }
+
     @DisplayName("createTargetUrl returns a valid Url for DOI strings that are DOI DX URLs")
     @Test
     public void createTargetUrlReturnsAValidUrlForDoiStringThatIsDoiDxUrl()
-        throws URISyntaxException {
+            throws URISyntaxException {
         targetURlReturnsAValidUrlForDoiStrings(DOI_DX_URL_PREFIX);
     }
 
     @DisplayName("createTargetUrl returns a valid Url for DOI strings that are DOI URLs")
     @Test
     public void createTargetUrlReturnsAValidUrlForDoiStringThatIsDoiURL()
-        throws URISyntaxException {
+            throws URISyntaxException {
         targetURlReturnsAValidUrlForDoiStrings(DOI_URL_PREFIX);
     }
 
     @Test
     @DisplayName("fetchDataForDoi returns an Optional with a json object for an existing URL")
     public void fetchDataForDoiReturnAnOptionalWithAJsonObjectForAnExistingUrl()
-        throws IOException, URISyntaxException {
+            throws IOException, URISyntaxException {
         Optional<String> result = crossRefClient.fetchDataForDoi(DOI_STRING).map(MetadataAndContentLocation::getJson);
         String expected = IoUtils.resourceAsString(CROSS_REF_SAMPLE_PATH);
         assertThat(result.isPresent(), is(true));
@@ -79,7 +104,7 @@ public class CrossRefClientTest {
     @Test
     @DisplayName("fetchDataForDoi returns an empty Optional for a non existing URL")
     public void fetchDataForDoiReturnAnEmptyOptionalForANonExistingUrl()
-        throws URISyntaxException {
+            throws URISyntaxException {
 
         CrossRefClient crossRefClient = crossRefClientReceives404();
 
@@ -90,7 +115,7 @@ public class CrossRefClientTest {
     @Test
     @DisplayName("fetchDataForDoi returns an empty Optional for an unknown error")
     public void fetchDataForDoiReturnAnEmptyOptionalForAnUnknownError()
-        throws URISyntaxException {
+            throws URISyntaxException {
         CrossRefClient crossRefClient = crossRefClientReceives500();
         Optional<String> result = crossRefClient.fetchDataForDoi(DOI_STRING).map(MetadataAndContentLocation::getJson);
         assertTrue(result.isEmpty());
@@ -102,7 +127,7 @@ public class CrossRefClientTest {
     }
 
     private void targetURlReturnsAValidUrlForDoiStrings(String doiPrefix)
-        throws URISyntaxException {
+            throws URISyntaxException {
         String doiURL = String.join("/", doiPrefix, DOI_STRING);
         String expected = String.join("/", CrossRefClient.CROSSREF_LINK, WORKS, DOI_STRING);
 
@@ -118,14 +143,14 @@ public class CrossRefClientTest {
 
     private CrossRefClient crossRefClientReceives404() {
         HttpResponseStatus404<String> errorResponse = new HttpResponseStatus404<>(
-            ERROR_MESSAGE);
+                ERROR_MESSAGE);
         MockHttpClient<String> mockHttpClient = new MockHttpClient<>(errorResponse);
         return new CrossRefClient(mockHttpClient);
     }
 
     private CrossRefClient crossRefClientReceives500() {
         HttpResponseStatus500<String> errorResponse = new HttpResponseStatus500<>(
-            ERROR_MESSAGE);
+                ERROR_MESSAGE);
         MockHttpClient<String> mockHttpClient = new MockHttpClient<>(errorResponse);
         return new CrossRefClient(mockHttpClient);
     }

--- a/doi-proxy/src/test/java/no/unit/nva/doi/utils/MockHttpClient.java
+++ b/doi-proxy/src/test/java/no/unit/nva/doi/utils/MockHttpClient.java
@@ -4,6 +4,7 @@ import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
 import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandler;
@@ -17,10 +18,15 @@ import javax.net.ssl.SSLParameters;
 
 public class MockHttpClient<R> extends HttpClient {
 
+    protected HttpRequest httpRequest;
     protected final AbstractHttpResponse<R> response;
 
     public MockHttpClient(AbstractHttpResponse<R> response) {
         this.response = response;
+    }
+
+    public HttpRequest getHttpRequest() {
+        return httpRequest;
     }
 
     // T must be the same with R
@@ -29,6 +35,7 @@ public class MockHttpClient<R> extends HttpClient {
     public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
                                                             BodyHandler<T> responseBodyHandler) {
 
+        this.httpRequest = request;
         return CompletableFuture.completedFuture(((HttpResponse<T>) response));
     }
 
@@ -36,6 +43,7 @@ public class MockHttpClient<R> extends HttpClient {
     public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request,
                                                             BodyHandler<T> responseBodyHandler,
                                                             PushPromiseHandler<T> pushPromiseHandler) {
+        this.httpRequest = request;
         return null;
     }
 
@@ -86,6 +94,7 @@ public class MockHttpClient<R> extends HttpClient {
 
     @Override
     public <T> HttpResponse<T> send(HttpRequest request, BodyHandler<T> responseBodyHandler) {
+        this.httpRequest = request;
         return null;
     }
 }


### PR DESCRIPTION
As was mandated in discussions about this client, the client should ensure that HTTPS schemes are used and an identifying user agent is provided (see "[Etiquette](https://github.com/CrossRef/rest-api-doc#Etiquette)").