### PR TITLE
Np 2077 date fetch

### DIFF
--- a/doi-transformer/src/main/java/no/unit/nva/doi/transformer/model/crossrefmodel/CrossrefDate.java
+++ b/doi-transformer/src/main/java/no/unit/nva/doi/transformer/model/crossrefmodel/CrossrefDate.java
@@ -1,6 +1,8 @@
 package no.unit.nva.doi.transformer.model.crossrefmodel;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import nva.commons.utils.JacocoGenerated;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -11,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import nva.commons.utils.JacocoGenerated;
 
 /**
  * Parses dates in the following (JSON) format.
@@ -34,6 +35,12 @@ import nva.commons.utils.JacocoGenerated;
  */
 @SuppressWarnings("PMD.MethodReturnsInternalArray")
 public class CrossrefDate {
+
+
+    public static final int YEAR_INDEX = 0;
+    public static final int MONTH_INDEX = 1;
+    public static final int DAY_INDEX = 2;
+    public static final int FROM_DATE_INDEX_IN_DATE_ARRAY = 0;
 
     private static String SELECT_ZONE_OFFSET_BY_CONSTANT = "";
     @JsonProperty("date-parts")
@@ -92,7 +99,7 @@ public class CrossrefDate {
         return Stream.empty();
     }
 
-    private boolean hasYear(int... dateArray) {
+    public boolean hasYear(int... dateArray) {
         return dateArray != null && dateArray.length > 0;
     }
 

--- a/doi-transformer/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
+++ b/doi-transformer/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.text.IsEmptyString.emptyString;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -75,6 +76,8 @@ public class CrossRefConverterTest extends ConversionTest {
     public static final String SOME_DOI = "10.1000/182";
     public static final String VALID_ISSN_A = "0306-4379";
     public static final String VALID_ISSN_B = "1066-8888";
+    public static final int EXPECTED_MONTH = 2;
+    public static final int EXPECTED_DAY = 20;
 
     private CrossRefDocument sampleInputDocument = createSampleDocument();
     private final CrossRefConverter converter = new CrossRefConverter();
@@ -384,6 +387,26 @@ public class CrossRefConverterTest extends ConversionTest {
 
         assertTrue(actualTags.isEmpty());
     }
+
+    @Test
+    @DisplayName("toPublication preserves all date parts when they are available")
+    public void toPublicationPreservesAllDatepartsWhenTheyAreAvailable() throws InvalidIssnException {
+        int[][] dateParts = new int[1][DATE_SIZE];
+        dateParts[0] = new int[]{EXPECTED_YEAR, EXPECTED_MONTH, EXPECTED_DAY};
+        CrossrefDate crossrefDate = new CrossrefDate();
+        crossrefDate.setDateParts(dateParts);
+
+        sampleInputDocument.setPublishedPrint(crossrefDate);
+        Publication actualDocument = toPublication(sampleInputDocument);
+        PublicationDate publicationDate = actualDocument.getEntityDescription().getDate();
+
+        assertEquals(""+EXPECTED_YEAR, publicationDate.getYear());
+        assertEquals(""+EXPECTED_MONTH, publicationDate.getMonth());
+        assertEquals(""+EXPECTED_DAY, publicationDate.getDay());
+
+    }
+
+
 
 
 

--- a/doi-transformer/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
+++ b/doi-transformer/src/test/java/no/unit/nva/doi/transformer/CrossRefConverterTest.java
@@ -126,9 +126,9 @@ public class CrossRefConverterTest extends ConversionTest {
     }
 
     @Test
-    @DisplayName("toPublication sets null EntityDescription date when input has no \"published-print\" date")
+    @DisplayName("toPublication sets null EntityDescription date when input has no \"issued\" date")
     public void entityDescriptionDateIsNullWhenInputDataHasNoPublicationDate() throws InvalidIssnException {
-        sampleInputDocument.setPublishedPrint(null);
+        sampleInputDocument.setIssued(null);
         Publication publicationWithoutDate = toPublication(sampleInputDocument);
         PublicationDate actualDate = publicationWithoutDate.getEntityDescription().getDate();
         assertThat(actualDate, is(nullValue()));
@@ -396,13 +396,13 @@ public class CrossRefConverterTest extends ConversionTest {
         CrossrefDate crossrefDate = new CrossrefDate();
         crossrefDate.setDateParts(dateParts);
 
-        sampleInputDocument.setPublishedPrint(crossrefDate);
+        sampleInputDocument.setIssued(crossrefDate);
         Publication actualDocument = toPublication(sampleInputDocument);
         PublicationDate publicationDate = actualDocument.getEntityDescription().getDate();
 
-        assertEquals(""+EXPECTED_YEAR, publicationDate.getYear());
-        assertEquals(""+EXPECTED_MONTH, publicationDate.getMonth());
-        assertEquals(""+EXPECTED_DAY, publicationDate.getDay());
+        assertEquals("" + EXPECTED_YEAR, publicationDate.getYear());
+        assertEquals("" + EXPECTED_MONTH, publicationDate.getMonth());
+        assertEquals("" + EXPECTED_DAY, publicationDate.getDay());
 
     }
 
@@ -425,6 +425,7 @@ public class CrossRefConverterTest extends ConversionTest {
         CrossRefDocument document = new CrossRefDocument();
         setAuthor(document);
         setPublicationDate(document);
+        setIssuedDate(document);    // Issued is required from CrossRef, is either printed-date or
         setTitle(document);
         setPublicationType(document);
         return document;
@@ -447,6 +448,15 @@ public class CrossRefConverterTest extends ConversionTest {
         date.setDateParts(dateParts);
         document.setPublishedPrint(date);
     }
+
+    private void setIssuedDate(CrossRefDocument document) {
+        int[][] dateParts = new int[1][DATE_SIZE];
+        dateParts[0] = new int[]{EXPECTED_YEAR, 2, 20};
+        CrossrefDate date = new CrossrefDate();
+        date.setDateParts(dateParts);
+        document.setIssued(date);
+    }
+
 
     private CrossRefDocument setAuthor(CrossRefDocument document) {
         CrossrefAuthor author = new CrossrefAuthor.Builder().withGivenName(AUTHOR_GIVEN_NAME)


### PR DESCRIPTION
Using 'issued' as a source for publisheddata when importing from crossref. Issued is a required field and consist of the first date in 'published-print' or 'published-online'