### PR TITLE
Restructure and extend doi functionality

### DIFF
--- a/metadata-transformer/src/main/java/no/unit/nva/metadata/MetadataConverter.java
+++ b/metadata-transformer/src/main/java/no/unit/nva/metadata/MetadataConverter.java
@@ -3,12 +3,9 @@ package no.unit.nva.metadata;
 import static nva.commons.core.JsonUtils.objectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Locale;
 import java.util.MissingResourceException;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import no.unit.nva.api.CreatePublicationRequest;
 import nva.commons.core.StringUtils;
 import org.eclipse.rdf4j.model.Model;
@@ -21,42 +18,24 @@ import org.slf4j.LoggerFactory;
 
 public class MetadataConverter {
 
-    public static final String DOI_PREFIX = "doi:";
-    public static final String DOI_ORG = "https://doi.org/";
     public static final String DCTERMS = "http://purl.org/dc/terms/";
-    public static final String IDENTIFIER = "identifier";
-    public static final String DOI_START = "10\\.[0-9]+/.*";
     public static final String LANGUAGE = "language";
     public static final String LEXVO_ORG = "https://lexvo.org/id/iso639-3/";
     public static final String ISO3_LANGUAGE_CODE_UNDEFINED = "und";
     private static final Logger logger = LoggerFactory.getLogger(MetadataConverter.class);
     private static final ValueFactory valueFactory = SimpleValueFactory.getInstance();
-    public final Pattern doiStartPattern;
     private final Model metadata;
     private final String jsonld;
 
     public MetadataConverter(Model metadata, String jsonld) {
         this.metadata = metadata;
         this.jsonld = jsonld;
-        this.doiStartPattern = Pattern.compile(DOI_START);
     }
 
     public CreatePublicationRequest toRequest() throws JsonProcessingException {
         CreatePublicationRequest request = objectMapper.readValue(jsonld, CreatePublicationRequest.class);
-        getDoiFromMetadata(metadata).ifPresent(request::addReferenceDoi);
         getLanguageFromMetadata(metadata).ifPresent(language -> request.getEntityDescription().setLanguage(language));
         return request;
-    }
-
-    private Optional<URI> getDoiFromMetadata(Model metadata) {
-        return metadata
-            .stream()
-            .filter(this::isDcIdentifier)
-            .map(Statement::getObject)
-            .map(Value::stringValue)
-            .map(this::toDoiUri)
-            .filter(Objects::nonNull)
-            .findFirst();
     }
 
     private Optional<URI> getLanguageFromMetadata(Model metadata) {
@@ -69,28 +48,8 @@ public class MetadataConverter {
             .findFirst();
     }
 
-    private boolean isDcIdentifier(Statement statement) {
-        return statement.getPredicate().equals(valueFactory.createIRI(DCTERMS, IDENTIFIER));
-    }
-
     private boolean isDcLanguage(Statement statement) {
         return valueFactory.createIRI(DCTERMS, LANGUAGE).equals(statement.getPredicate());
-    }
-
-    private URI toDoiUri(String stringValue) {
-        URI doi = null;
-        try {
-            if (stringValue.startsWith(DOI_PREFIX)) {
-                doi = createUriReplaceDoiPrefixWithHost(stringValue);
-            } else if (stringValue.startsWith(DOI_ORG)) {
-                doi = new URI(stringValue);
-            } else if (hasDoiPattern(stringValue)) {
-                doi = createUriAddHostToDoiPath(stringValue);
-            }
-        } catch (URISyntaxException e) {
-            logger.warn("Can not create URI from DOI string value", e);
-        }
-        return doi;
     }
 
     private URI toLexvoUri(String language) {
@@ -104,17 +63,5 @@ public class MetadataConverter {
         }
 
         return URI.create(LEXVO_ORG + iso3LanguageCode);
-    }
-
-    private URI createUriAddHostToDoiPath(String stringValue) throws URISyntaxException {
-        return new URI(DOI_ORG + stringValue);
-    }
-
-    private boolean hasDoiPattern(String stringValue) {
-        return doiStartPattern.matcher(stringValue).matches();
-    }
-
-    private URI createUriReplaceDoiPrefixWithHost(String stringValue) throws URISyntaxException {
-        return new URI(stringValue.replace(DOI_PREFIX, DOI_ORG));
     }
 }

--- a/metadata-transformer/src/main/java/no/unit/nva/metadata/service/MetadataService.java
+++ b/metadata-transformer/src/main/java/no/unit/nva/metadata/service/MetadataService.java
@@ -148,11 +148,11 @@ public class MetadataService {
     private Optional<Statement> toBiboDoi(Statement statement) throws IOException,
             InterruptedException {
         String value = statement.getObject().stringValue();
-        return getDoi(value).map(doiString -> valueFactory.createStatement(statement.getSubject(),
+        return extractDoi(value).map(doiString -> valueFactory.createStatement(statement.getSubject(),
                 valueFactory.createIRI(BIBO_DOI), valueFactory.createLiteral(doiString)));
     }
 
-    private Optional<String> getDoi(String value) throws IOException, InterruptedException {
+    private Optional<String> extractDoi(String value) throws IOException, InterruptedException {
         return isShortDoi(value) ? fetchDoiUriFromShortDoi(value)
                 : Optional.of(DOI_PREFIX + value.substring(value.indexOf(DOI_FIRST_PART)));
     }

--- a/metadata-transformer/src/main/resources/query.sparql
+++ b/metadata-transformer/src/main/resources/query.sparql
@@ -1,4 +1,5 @@
 PREFIX any23: <http://vocab.sindice.net/any23#>
+PREFIX bibo: <http://purl.org/ontology/bibo/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX unit: <https://nva.unit.no/publication#>
 
@@ -11,7 +12,8 @@ CONSTRUCT {
     unit:abstract ?abstract ;
     unit:tag ?tag ;
     unit:contributor ?contributorNode ;
-    unit:date ?dateNode .
+    unit:date ?dateNode ;
+    unit:reference ?referenceNode .
   ?contributorNode a unit:Contributor ;
     unit:identity ?identityNode .
   ?identityNode a unit:Identity ;
@@ -20,6 +22,8 @@ CONSTRUCT {
     unit:year ?year ;
     unit:month ?month ;
     unit:day ?day .
+  ?referenceNode a unit:Reference ;
+    unit:doi ?doi .
 } WHERE {
   SELECT DISTINCT (STR(?title) AS ?mainTitle)
                   ?entityNode
@@ -34,9 +38,10 @@ CONSTRUCT {
                   ?dateNode
                   ?year
                   ?month
-                  ?day {
-
-    BIND (BNODE() AS ?entityNode)
+                  ?day
+                  ?referenceNode
+                  ?doi {
+    BIND(BNODE("entityNode") AS ?entityNode)
     {
       SELECT ?title WHERE {
         VALUES ?titleProperty { dcterms:title any23:citation_title }
@@ -98,6 +103,12 @@ CONSTRUCT {
     }
     UNION {
         <__URI__> dcterms:language ?rawLanguage .
+    } UNION {
+      SELECT ?doi ?referenceNode WHERE {
+        <__URI__> bibo:doi ?doi
+          FILTER (BOUND(?doi))
+          BIND(BNODE("referenceNode") AS ?referenceNode)
+      } LIMIT 1
     }
   }
 }

--- a/metadata-transformer/src/test/java/no/unit/nva/metadata/service/testdata/ValidDoiArgumentsProvider.java
+++ b/metadata-transformer/src/test/java/no/unit/nva/metadata/service/testdata/ValidDoiArgumentsProvider.java
@@ -1,0 +1,32 @@
+package no.unit.nva.metadata.service.testdata;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class ValidDoiArgumentsProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(
+                Arguments.of("https://doi.org/10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("http://doi.org/10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("https://dx.doi.org/10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("http://dx.doi.org/10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("doi:10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("doc:10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("DOI:10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("DOC:10.1109/5.771073", URI.create("https://doi.org/10.1109/5.771073")),
+                Arguments.of("https://doi.org/bwfc", URI.create("https://doi.org/10.7774/CEVR.2016.5.1.1")),
+                Arguments.of("https://doi.org/bwfc/", URI.create("https://doi.org/10.7774/CEVR.2016.5.1.1")),
+                Arguments.of("http://doi.org/bwfc", URI.create("https://doi.org/10.7774/CEVR.2016.5.1.1")),
+                Arguments.of("http://doi.org/bwfc/", URI.create("https://doi.org/10.7774/CEVR.2016.5.1.1"))
+        );
+    }
+}


### PR DESCRIPTION
- Moves the parsing and filtering of DOIs to pre-validation and fixing
- Extends DOI functionality to include more variants
  - DOC
  - shortDoi
- Unifies handling of data to the SPARQL query