### PR TITLE
Add missing environment variable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -191,6 +191,7 @@ Resources:
           BARE_PROXY_API_URI: !Sub 'https://${CustomDomain}'
           CROSSREFPLUSAPITOKEN_NAME: !Ref CrossrefPlusApiTokenName
           CROSSREFPLUSAPITOKEN_KEY:  !Ref CrossrefPlusApiTokenKey
+          ID_NAMESPACE: !Sub 'https://api.${CustomDomain}/${CustomDomainBasePath}'
       Events:
         NvaDoi:
           Type: Api


### PR DESCRIPTION
Have set this up as per nva-publication-api, but I cannot see the utility of implementing anything around it as it will surely be overwritten when the publication is initialised in nva-publication-api