### PR TITLE
prevent fetching to many orcids from cristin api

### DIFF
--- a/create-publication-from-doi/src/main/java/no/unit/nva/doi/fetch/service/IdentityUpdater.java
+++ b/create-publication-from-doi/src/main/java/no/unit/nva/doi/fetch/service/IdentityUpdater.java
@@ -18,6 +18,7 @@ public final class IdentityUpdater {
 
     public static final String PROBLEM_UPDATING_IDENTITY_MESSAGE = "Problem updating Identity, ignoring and moving on";
     private static final Logger logger = LoggerFactory.getLogger(IdentityUpdater.class);
+    public static final int MAX_CONTRIBUTORS_TO_LOOKUP = 10;
 
     private IdentityUpdater() {
     }
@@ -57,8 +58,9 @@ public final class IdentityUpdater {
 
     private static void updateContributors(CristinProxyClient cristinProxyClient, Publication publication,
                                            List<Contributor> contributors) {
-        var contributorsWithOnlyOrcid = contributors.stream().filter(IdentityUpdater::hasOcidButNotIdentifier).toList();
-        if (contributorsWithOnlyOrcid.size() > 10) {
+        var contributorsWithOnlyOrcid = contributors.stream()
+                                            .filter(IdentityUpdater::hasOrcidButNotIdentifier).toList();
+        if (contributorsWithOnlyOrcid.size() > MAX_CONTRIBUTORS_TO_LOOKUP) {
             logger.warn("Skipper updateContributors as too many without known cristin-identifier "
                         + publication.getIdentifier());
             return;
@@ -69,7 +71,7 @@ public final class IdentityUpdater {
         );
     }
 
-    private static boolean hasOcidButNotIdentifier(Contributor contributor) {
+    private static boolean hasOrcidButNotIdentifier(Contributor contributor) {
         var identity = contributor.getIdentity();
         return nonNull(identity) && isNull(identity.getId()) && nonNull(identity.getOrcId());
     }

--- a/create-publication-from-doi/src/test/java/no/unit/nva/doi/fetch/service/IdentityUpdaterTest.java
+++ b/create-publication-from-doi/src/test/java/no/unit/nva/doi/fetch/service/IdentityUpdaterTest.java
@@ -102,16 +102,16 @@ class IdentityUpdaterTest {
     }
 
     @Test
-    public void shouldNotEnrichContributorsWhenMoreThan10AreMissingCristinIdentifier() {
-        var identies = Collections.nCopies(11, 1).stream().map(i -> createIdentityWithOrcid()).toList();
-        var publication = createPublicationWithIdentites(identies);
+    public void shouldNotEnrichContributorsWhenMoreThanTenUnverifiedContributorsExist() {
+        var identities = Collections.nCopies(11, 1).stream().map(i -> createIdentityWithOrcid()).toList();
+        var publication = createPublicationWithIdentites(identities);
         var cristinProxyClient = mock(CristinProxyClient.class);
         var sampleIdentifier = URI.create(SAMPLE_IDENTITY_IDENTIFIER);
         when(cristinProxyClient.lookupIdentifierFromOrcid(any())).thenReturn(Optional.of(sampleIdentifier));
 
         var updatedPublication = IdentityUpdater.enrichPublicationCreators(cristinProxyClient, publication);
 
-        assertThat(identies, Every.everyItem(HasPropertyWithValue.hasProperty("id", equalTo(null))));
+        assertThat(identities, Every.everyItem(HasPropertyWithValue.hasProperty("id", equalTo(null))));
         assertThat(updatedPublication, equalTo(publication));
     }
 

--- a/create-publication-from-doi/src/test/java/no/unit/nva/doi/fetch/service/IdentityUpdaterTest.java
+++ b/create-publication-from-doi/src/test/java/no/unit/nva/doi/fetch/service/IdentityUpdaterTest.java
@@ -13,6 +13,8 @@ import no.unit.nva.model.ResourceOwner;
 import no.unit.nva.model.Username;
 import no.unit.nva.model.role.Role;
 import no.unit.nva.model.role.RoleType;
+import org.hamcrest.beans.HasPropertyWithValue;
+import org.hamcrest.core.Every;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -22,12 +24,15 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static net.bytebuddy.matcher.ElementMatchers.is;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -89,10 +94,24 @@ class IdentityUpdaterTest {
 
     @Test
     public void shouldNotAlterPublicationWhenMissingIdentityCallingEnrichPublicationCreators() {
-        var publication = createPublicationWithIdentity(null);
+        var publication = createPublicationWithIdentites(List.of());
         var cristinProxyClient = mock(CristinProxyClient.class);
         var updatedPublication = IdentityUpdater.enrichPublicationCreators(cristinProxyClient, publication);
 
+        assertThat(updatedPublication, equalTo(publication));
+    }
+
+    @Test
+    public void shouldNotEnrichContributorsWhenMoreThan10AreMissingCristinIdentifier() {
+        var identies = Collections.nCopies(11, 1).stream().map(i -> createIdentityWithOrcid()).toList();
+        var publication = createPublicationWithIdentites(identies);
+        var cristinProxyClient = mock(CristinProxyClient.class);
+        var sampleIdentifier = URI.create(SAMPLE_IDENTITY_IDENTIFIER);
+        when(cristinProxyClient.lookupIdentifierFromOrcid(any())).thenReturn(Optional.of(sampleIdentifier));
+
+        var updatedPublication = IdentityUpdater.enrichPublicationCreators(cristinProxyClient, publication);
+
+        assertThat(identies, Every.everyItem(HasPropertyWithValue.hasProperty("id", equalTo(null))));
         assertThat(updatedPublication, equalTo(publication));
     }
 
@@ -122,22 +141,28 @@ class IdentityUpdaterTest {
 
 
     private Publication createPublicationWithIdentity(Identity identity) {
-        var contributor = new Contributor.Builder()
-                .withRole(new RoleType(Role.CREATOR))
-                .withIdentity(identity)
-                .build();
+        return createPublicationWithIdentites(List.of(identity));
+    }
+
+    private Publication createPublicationWithIdentites(List<Identity> identites) {
+        var contributors = identites.stream().map(identity -> new Contributor.Builder()
+                                                                  .withRole(new RoleType(Role.CREATOR))
+                                                                  .withIdentity(identity)
+                                                                  .build())
+                               .toList();
+
         return new Publication.Builder()
-                .withIdentifier(new SortableIdentifier(UUID.randomUUID().toString()))
-                .withModifiedDate(Instant.now())
-                .withResourceOwner(randomResourceOwner())
-                .withPublisher(new Organization.Builder()
-                        .withId(URI.create("http://example.org/publisher/1"))
-                        .build()
-                )
-                .withEntityDescription(new EntityDescription.Builder()
-                        .withContributors(List.of(contributor))
-                        .build())
-                .build();
+                   .withIdentifier(new SortableIdentifier(UUID.randomUUID().toString()))
+                   .withModifiedDate(Instant.now())
+                   .withResourceOwner(randomResourceOwner())
+                   .withPublisher(new Organization.Builder()
+                                      .withId(URI.create("http://example.org/publisher/1"))
+                                      .build()
+                   )
+                   .withEntityDescription(new EntityDescription.Builder()
+                                              .withContributors(contributors)
+                                              .build())
+                   .build();
     }
 
     private ResourceOwner randomResourceOwner() {


### PR DESCRIPTION
If we have a publication with too many contributors we should skip looking them up though Cristin. 
https://unit.atlassian.net/browse/NP-46635